### PR TITLE
Updated dp_svm.py to increase scipy.optimize.minimize maxfun limit

### DIFF
--- a/scripts/dp_stats/dp_svm.py
+++ b/scripts/dp_stats/dp_svm.py
@@ -170,6 +170,8 @@ def train_svm_objectiveperturb(XY, num, dim, lambda_, epsilon, huberconst):
     w0 = np.zeros(dim)
     beta = epsilon_p / 2
     b = noisevector(dim, beta)
+    
+    '''
     res = minimize(
         eval_svm,
         w0,
@@ -177,6 +179,17 @@ def train_svm_objectiveperturb(XY, num, dim, lambda_, epsilon, huberconst):
         method="L-BFGS-B",
         bounds=None,
     )
+    '''
+    
+    res = minimize(
+        eval_svm,
+        w0,
+        args=(XY, num, lambda_, b, huberconst),
+        method="L-BFGS-B",
+        bounds=None,
+        maxfun=np.inf
+    )
+    
     if not res.success:
         raise Exception(res.message)
     w_priv = res.x

--- a/scripts/dp_stats/dp_svm.py
+++ b/scripts/dp_stats/dp_svm.py
@@ -179,6 +179,9 @@ def train_svm_objectiveperturb(XY, num, dim, lambda_, epsilon, huberconst):
         method="L-BFGS-B",
         bounds=None,
     )
+    From https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html#optimize-minimize-lbfgsb, it says maxfun: int
+    Maximum number of function evaluations. Note that this function may violate the limit because of evaluating gradients by numerical differentiation. 
+    Edited the minimize function and add maxfun argument
     '''
     
     res = minimize(


### PR DESCRIPTION
From https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html#optimize-minimize-lbfgsb,maxfun: Maximum number of function evaluations. Note that this function may violate the limit because of evaluating gradients by numerical differentiation. Updated the func to include parameter maxfun=np.inf